### PR TITLE
Add DiscordSRV pass-prolongation notifications and config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.discordsrv</groupId>
+            <artifactId>discordsrv</artifactId>
+            <version>1.28.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.10.2</version>
@@ -458,6 +464,10 @@
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>loohpjames-repo</id>
+            <url>https://repo.loohpjames.com/repository/</url>
         </repository>
     </repositories>
 </project>

--- a/src/main/java/org/joupen/JoupenPlugin.java
+++ b/src/main/java/org/joupen/JoupenPlugin.java
@@ -16,6 +16,7 @@ import org.joupen.database.DatabaseManager;
 import org.joupen.database.TransactionManager;
 import org.joupen.events.PlayerJoinEventHandler;
 import org.joupen.events.PlayerProlongedEvent;
+import org.joupen.events.listeners.JoupenDiscordSrvListener;
 import org.joupen.events.listeners.PlayerProlongedBroadcastListener;
 import org.joupen.messaging.Messaging;
 import org.joupen.repository.PlayerRepository;
@@ -73,6 +74,7 @@ public class JoupenPlugin extends JavaPlugin {
 
         new JoupenCommand(playerRepository, transactionManager);
         Bukkit.getPluginManager().registerEvents(new PlayerJoinEventHandler(playerRepository), this);
+        Bukkit.getPluginManager().registerEvents(new JoupenDiscordSrvListener(), this);
 
         EventUtils.register(PlayerProlongedEvent.class, new PlayerProlongedBroadcastListener());
 

--- a/src/main/java/org/joupen/events/listeners/JoupenDiscordSrvListener.java
+++ b/src/main/java/org/joupen/events/listeners/JoupenDiscordSrvListener.java
@@ -1,0 +1,87 @@
+package org.joupen.events.listeners;
+
+import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.dependencies.jda.api.EmbedBuilder;
+import github.scarsz.discordsrv.dependencies.jda.api.entities.TextChannel;
+import lombok.extern.slf4j.Slf4j;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.joupen.bukkit.event.JoupenPassProlongedEvent;
+import org.joupen.utils.JoupenProperties;
+import org.joupen.utils.TimeUtils;
+
+import java.awt.Color;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+public class JoupenDiscordSrvListener implements Listener {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm");
+
+    private final AtomicBoolean missingDiscordSrvWarned = new AtomicBoolean(false);
+    private final AtomicBoolean missingChannelWarned = new AtomicBoolean(false);
+
+    @EventHandler
+    public void onPassProlonged(JoupenPassProlongedEvent event) {
+        if (!JoupenProperties.discordSrvPassProlongedEnabled) {
+            return;
+        }
+
+        DiscordSRV discordSRV = DiscordSRV.getPlugin();
+        if (discordSRV == null || !discordSRV.isEnabled()) {
+            warnOnce(missingDiscordSrvWarned, "DiscordSRV is not installed or disabled, pass prolongation notifications are skipped");
+            return;
+        }
+
+        TextChannel channel = discordSRV.getDestinationTextChannelForGameChannelName(JoupenProperties.discordSrvPassProlongedChannel);
+        if (channel == null) {
+            warnOnce(
+                    missingChannelWarned,
+                    "DiscordSRV channel '{}' was not found, pass prolongation notifications are skipped",
+                    JoupenProperties.discordSrvPassProlongedChannel
+            );
+            return;
+        }
+
+        String playerName = event.getName();
+        String author = event.isGift()
+                ? playerName + " получил проходку! (подарок)"
+                : playerName + " получил проходку!";
+
+        StringBuilder description = new StringBuilder("Дата окончания проходки: ")
+                .append(event.getValidUntil().format(DATE_TIME_FORMATTER));
+
+        if (JoupenProperties.discordSrvPassProlongedShowDuration) {
+            description
+                    .append("\nПродление: ")
+                    .append(TimeUtils.formatDuration(event.getDuration()));
+        }
+
+        EmbedBuilder embedBuilder = new EmbedBuilder()
+                .setColor(parseColor(JoupenProperties.discordSrvPassProlongedColor))
+                .setAuthor(author, null, "https://crafthead.net/helm/" + event.getUuid())
+                .setDescription(description.toString());
+
+        channel.sendMessageEmbeds(embedBuilder.build()).queue(
+                success -> {
+                },
+                error -> log.warn("Failed to send DiscordSRV pass prolongation notification: {}", error.getMessage())
+        );
+    }
+
+    private Color parseColor(String hexColor) {
+        try {
+            return Color.decode(hexColor);
+        } catch (NumberFormatException e) {
+            log.warn("Invalid DiscordSRV embed color '{}', fallback to #30d5c8", hexColor);
+            return Color.decode("#30d5c8");
+        }
+    }
+
+    private void warnOnce(AtomicBoolean guard, String message, Object... args) {
+        if (guard.compareAndSet(false, true)) {
+            log.warn(message, args);
+        }
+    }
+}

--- a/src/main/java/org/joupen/utils/JoupenProperties.java
+++ b/src/main/java/org/joupen/utils/JoupenProperties.java
@@ -18,6 +18,10 @@ public final class JoupenProperties {
     public static Boolean migrate = false;
     public static Boolean enabled = true;
     public static Map<String, Object> dbConfig;
+    public static boolean discordSrvPassProlongedEnabled = true;
+    public static String discordSrvPassProlongedChannel = "mc-live";
+    public static String discordSrvPassProlongedColor = "#30d5c8";
+    public static boolean discordSrvPassProlongedShowDuration = false;
     public static boolean isInitialized = false;
 
     private static final List<ConfigConverter> CONVERTERS = List.of(
@@ -95,6 +99,24 @@ public final class JoupenProperties {
         log.info("Plugin config: playersFilepath={}, enabled={}, useSql={}, migrate={}", playersFilepath, enabled,
                 useSql, migrate);
 
+        Map<String, Object> discordSrvConfig = getMap(config, "discordsrv");
+        Map<String, Object> passProlongedConfig = getMap(discordSrvConfig, "pass-prolonged");
+        discordSrvPassProlongedEnabled = Boolean.parseBoolean(
+                String.valueOf(passProlongedConfig.getOrDefault("enabled", true))
+        );
+        discordSrvPassProlongedChannel = String.valueOf(passProlongedConfig.getOrDefault("channel", "mc-live"));
+        discordSrvPassProlongedColor = String.valueOf(passProlongedConfig.getOrDefault("color", "#30d5c8"));
+        discordSrvPassProlongedShowDuration = Boolean.parseBoolean(
+                String.valueOf(passProlongedConfig.getOrDefault("show-duration", false))
+        );
+        log.info(
+                "DiscordSRV config: enabled={}, channel={}, color={}, showDuration={}",
+                discordSrvPassProlongedEnabled,
+                discordSrvPassProlongedChannel,
+                discordSrvPassProlongedColor,
+                discordSrvPassProlongedShowDuration
+        );
+
         if (useSql) {
             dbConfig = (Map<String, Object>) config.getOrDefault("database", Map.of());
             log.info("Database config: {}", dbConfig);
@@ -133,6 +155,12 @@ public final class JoupenProperties {
                   password: user_password
                   driverClassName: org.mariadb.jdbc.Driver
                   maximumPoolSize: 10
+                discordsrv:
+                  pass-prolonged:
+                    enabled: true
+                    channel: mc-live
+                    color: "#30d5c8"
+                    show-duration: false
                 """;
         try {
             if (configFile.exists()) {
@@ -145,5 +173,14 @@ public final class JoupenProperties {
             log.error("Failed to create default config.yml: {} - {}", configFile.getAbsolutePath(), e.getMessage());
             throw new IllegalStateException("Failed to create default config.yml", e);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getMap(Map<String, Object> source, String key) {
+        Object value = source.get(key);
+        if (value instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return Map.of();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ main: org.joupen.JoupenPlugin
 api-version: 1.20
 author: JouTak
 description: Login plugin for JouTak server
+softdepend: [DiscordSRV]
 
 commands:
   joupen:


### PR DESCRIPTION
### Motivation
- Add DiscordSRV integration to notify Discord channels when a player's pass is prolonged. 
- Make notifications configurable (enable/disable, channel, color, show duration) and include a soft dependency on DiscordSRV.

### Description
- Added `discordsrv` dependency and a repository entry in `pom.xml` to resolve DiscordSRV artifacts.
- Introduced `JoupenDiscordSrvListener` which listens for `JoupenPassProlongedEvent`, builds an embed (with color parsing and duration option) and sends it to the configured DiscordSRV channel, including guarded warnings if DiscordSRV or the channel is missing.
- Registered the new listener in `JoupenPlugin`'s `onEnable` and declared `softdepend: [DiscordSRV]` in `plugin.yml`.
- Extended `JoupenProperties` with DiscordSRV-related properties, YAML parsing defaults, and a helper `getMap` method; added default `discordsrv.pass-prolonged` block to the generated config.

### Testing
- No unit tests were added or modified for this change.
- Verified the project compiles successfully using `mvn -DskipTests package`, and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00e328368832e9682538692a3c67a)